### PR TITLE
Remove unnecessary end comma from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
         "rubocop-rspec",
         "guard",
         "guard-rspec",
-        "guard-rubocop",
+        "guard-rubocop"
       ],
       "automerge": true
     }


### PR DESCRIPTION
json なのに不要な末尾カンマをつけてしまっていたので削除します