### PR TITLE
activesupportと依存関係にあるbigdecimalのversionを上げました

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.1.1)
-    bigdecimal (1.4.4)
+    bigdecimal (3.1.4)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
@@ -221,4 +221,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.12
+   2.4.21


### PR DESCRIPTION
# やりたいこと

ref: https://github.com/kufu/yokoso/pull/161

renovateで作成されたPRのbigdecimalのversionが1.4.4となっているが、ローカルで `1.4.4` のgemをinstallしようとするとmakeファイル作成時にコンパイルができずに落ちる事象が発生している

```
❯ bundle install
Fetching gem metadata from https://rubygems.org/.........
Installing bigdecimal 1.4.4 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bigdecimal-1.4.4/ext/bigdecimal
/Users/yusaku.tabei/.rbenv/versions/3.2.2/bin/ruby extconf.rb
checking RUBY_BIGDECIMAL_VERSION... 1.4.4
checking for labs() in stdlib.h... yes
checking for llabs() in stdlib.h... yes
checking for finite() in math.h... no
checking for isfinite() in math.h... no
checking for struct RRational in ruby.h... no
checking for rb_rational_num() in ruby.h... yes
checking for rb_rational_den() in ruby.h... yes
checking for rb_array_const_ptr() in ruby.h... yes
checking for rb_sym2str() in ruby.h... yes
creating Makefile

current directory: /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bigdecimal-1.4.4/ext/bigdecimal
make DESTDIR\= sitearchdir\=./.gem.20231019-95082-c3vyqs sitelibdir\=./.gem.20231019-95082-c3vyqs clean

current directory: /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bigdecimal-1.4.4/ext/bigdecimal
make DESTDIR\= sitearchdir\=./.gem.20231019-95082-c3vyqs sitelibdir\=./.gem.20231019-95082-c3vyqs
compiling bigdecimal.c
bigdecimal.c:348:28: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
                       INT2NUM(p->MaxPrec*VpBaseFig()));
                       ~~~~~~~ ~~~~~~~~~~^~~~~~~~~~~~
bigdecimal.c:347:39: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
    obj = rb_assoc_new(INT2NUM(p->Prec*VpBaseFig()),
                       ~~~~~~~ ~~~~~~~^~~~~~~~~~~~
bigdecimal.c:421:5: error: call to undeclared function 'rb_check_safe_obj'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    rb_check_safe_obj(str);
    ^
bigdecimal.c:421:5: note: did you mean 'rb_check_safe_str'?
/Users/yusaku.tabei/.rbenv/versions/3.2.2/include/ruby-3.2.0/ruby/internal/core/rstring.h:383:6: note: 'rb_check_safe_str' declared here
void rb_check_safe_str(VALUE);
     ^
bigdecimal.c:2030:6: error: call to undeclared function 'rb_check_safe_obj'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            rb_check_safe_obj(f);
            ^
bigdecimal.c:2135:30: warning: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
    rb_ary_push(obj, INT2NUM(e));
                     ~~~~~~~ ^
bigdecimal.c:2148:20: warning: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
    return INT2NUM(e);
           ~~~~~~~ ^
bigdecimal.c:2766:27: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
    VALUE  nCur = INT2NUM(VpGetPrecLimit());
                  ~~~~~~~ ^~~~~~~~~~~~~~~~
bigdecimal.c:6019:18: warning: variable 'prec' set but not used [-Wunused-but-set-variable]
    SIGNED_VALUE prec;
                 ^
6 warnings and 2 errors generated.
make: *** [bigdecimal.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bigdecimal-1.4.4 for inspection.
Results logged to /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/extensions/arm64-darwin-21/3.2.0/bigdecimal-1.4.4/gem_make.out

  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/ext/builder.rb:120:in `run'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/ext/builder.rb:53:in `block in make'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/ext/builder.rb:45:in `each'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/ext/builder.rb:45:in `make'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/ext/ext_conf_builder.rb:42:in `build'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/ext/builder.rb:188:in `build_extension'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/ext/builder.rb:222:in `block in build_extensions'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/ext/builder.rb:219:in `each'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/ext/builder.rb:219:in `build_extensions'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/installer.rb:844:in `build_extensions'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/rubygems_gem_installer.rb:28:in `install'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/source/rubygems.rb:203:in `install'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/installer/gem_installer.rb:54:in `install'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/installer/parallel_installer.rb:130:in `do_install'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/installer/parallel_installer.rb:121:in `block in worker_pool'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/worker.rb:62:in `apply_func'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/worker.rb:57:in `block in process_queue'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/worker.rb:54:in `loop'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/worker.rb:54:in `process_queue'
  /Users/yusaku.tabei/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing bigdecimal (1.4.4), and Bundler cannot continue.
```

activesupportで要求されているbigdecimalのversionは `>=0` で最新のものに変えても問題ないので上げてしまいたい。

# やったこと

- activesupportをgemfileから削除 -> 再度追加して `bundle install` を実行したところ、bigdecimal(3.1.4) が入ったので問題なさそう