### PR TITLE
入館申請のQRコードの送信先を選択できるように修正しました

### DIFF
--- a/app/controllers/slack_notification.rb
+++ b/app/controllers/slack_notification.rb
@@ -38,7 +38,7 @@ module SlackNotification
 
     ChatMessageSender.new.post_public_message(
       icon_emoji: ":office:",
-      channel: res.channel, # DM に送るの切り替えを入れる場合はここに判定が入る
+      channel: res.channel,
       text: "#{text_guide_jap}\n#{text_guide_eng}",
       attachments: [
         {

--- a/app/controllers/slack_notification.rb
+++ b/app/controllers/slack_notification.rb
@@ -38,7 +38,7 @@ module SlackNotification
 
     ChatMessageSender.new.post_public_message(
       icon_emoji: ":office:",
-      channel: res.channel,
+      channel: res.channel, # DM に送るの切り替えを入れる場合はここに判定が入る
       text: "#{text_guide_jap}\n#{text_guide_eng}",
       attachments: [
         {

--- a/app/models/admission_code_message.rb
+++ b/app/models/admission_code_message.rb
@@ -13,20 +13,25 @@ class AdmissionCodeMessage
 
   def post
     chat_message_sender =  ChatMessageSender.new
-    case ENV.fetch("SEND_MODE")
-    when "Public" then
-      chat_message_sender.post_public_message(api_post_body)
-    when "Private" then
-      chat_message_sender.post_public_message(api_post_body_direct_message)
-    when "Both" then
-      chat_message_sender.post_public_message(api_post_body)
-      chat_message_sender.post_public_message(api_post_body_direct_message)
-    else
-      chat_message_sender.post_public_message(api_post_body)
+    res = nil
+    if send_to_channel?
+      res = chat_message_sender.post_public_message(api_post_body)
     end
+    if send_to_direct_message?
+      res = chat_message_sender.post_public_message(api_post_body_direct_message)
+    end
+    res
   end
 
   private
+
+  def send_to_channel?
+    %w[CHANNEL BOTH].include?(ENV.fetch("SEND_MODE"))
+  end
+
+  def send_to_direct_message?
+    %w[DM Both].include?(ENV.fetch("SEND_MODE"))
+  end
 
   # @return [Hash] postMessage API post body
   # @see https://api.slack.com/methods/chat.postMessage

--- a/app/models/admission_code_message.rb
+++ b/app/models/admission_code_message.rb
@@ -12,7 +12,18 @@ class AdmissionCodeMessage
   end
 
   def post
-    ChatMessageSender.new.post_public_message(api_post_body)
+    chat_message_sender =  ChatMessageSender.new
+    case ENV.fetch("SEND_MODE")
+    when "Public" then
+      chat_message_sender.post_public_message(api_post_body)
+    when "Private" then
+      chat_message_sender.post_public_message(api_post_body_direct_message)
+    when "Both" then
+      chat_message_sender.post_public_message(api_post_body)
+      chat_message_sender.post_public_message(api_post_body_direct_message)
+    else
+      chat_message_sender.post_public_message(api_post_body)
+    end
   end
 
   private
@@ -22,6 +33,16 @@ class AdmissionCodeMessage
   # @see https://github.com/slack-ruby/slack-ruby-client/blob/master/lib/slack/web/api/endpoints/chat.rb
   # @private
   def api_post_body
+    { icon_emoji: MESSAGES["notification"]["icon"],
+      channel: ENV.fetch("SLACK_CHANNEL"),
+      text: "<@#{@email.slack_id}> #{MESSAGES['notification']['text_notification']}",
+      attachments: [
+        color: "good",
+        fields: attachment_fields
+      ] }
+  end
+
+  def api_post_body_direct_message
     { icon_emoji: MESSAGES["notification"]["icon"],
       channel: @email.slack_id,
       text: "<@#{@email.slack_id}> #{MESSAGES['notification']['text_notification']}",

--- a/app/models/admission_code_message.rb
+++ b/app/models/admission_code_message.rb
@@ -12,14 +12,9 @@ class AdmissionCodeMessage
   end
 
   def post
-    chat_message_sender =  ChatMessageSender.new
-    res = nil
-    if send_to_channel?
-      res = chat_message_sender.post_public_message(api_post_body)
-    end
-    if send_to_direct_message?
-      res = chat_message_sender.post_public_message(api_post_body_direct_message)
-    end
+    chat_message_sender = ChatMessageSender.new
+    res = chat_message_sender.post_public_message(api_post_body) if send_to_channel?
+    res = chat_message_sender.post_public_message(api_post_body_direct_message) if send_to_direct_message?
     res
   end
 
@@ -30,7 +25,7 @@ class AdmissionCodeMessage
   end
 
   def send_to_direct_message?
-    %w[DM Both].include?(ENV.fetch("SEND_MODE"))
+    %w[DM BOTH].include?(ENV.fetch("SEND_MODE"))
   end
 
   # @return [Hash] postMessage API post body

--- a/app/models/admission_code_message.rb
+++ b/app/models/admission_code_message.rb
@@ -23,7 +23,7 @@ class AdmissionCodeMessage
   # @private
   def api_post_body
     { icon_emoji: MESSAGES["notification"]["icon"],
-      channel: ENV.fetch("SLACK_CHANNEL"),
+      channel: @email.slack_id,
       text: "<@#{@email.slack_id}> #{MESSAGES['notification']['text_notification']}",
       attachments: [
         color: "good",

--- a/app/models/chat_message_sender.rb
+++ b/app/models/chat_message_sender.rb
@@ -14,6 +14,10 @@ class ChatMessageSender
     @slack_api_client.chat_postMessage(post_body)
   end
 
+  def post_direct_message(post_body)
+    @slack_api_client.chat_postMessage(post_body)
+  end
+
   # 特定のユーザーだけに見える形で投稿
   # @param post_body [Hash]
   # @see https://api.slack.com/methods/chat.postEphemeral

--- a/app/models/slack_message.rb
+++ b/app/models/slack_message.rb
@@ -31,8 +31,22 @@ class SlackMessage
     { icon_emoji: MESSAGES["intarctive"]["icon"],
       channel: @dialog_submission.slack_channel_id,
       user: @dialog_submission.slack_user_id,
-      text: MESSAGES["intarctive"]["text_notification"],
+      text:,
       attachments: [attachment(fields: received_message_attachment_fields)] }
+  end
+
+  def text
+    if send_to_direct_message?
+      MESSAGES["intarctive"]["dm_text_notification"]
+    else
+      MESSAGES["intarctive"]["text_notification"]
+    end
+  end
+
+  # @private
+  # @return [Boolean]
+  def send_to_direct_message?
+    %w[DM BOTH].include?(ENV.fetch("SEND_MODE"))
   end
 
   # @return [Array] attachment_field array

--- a/config/messages.sample.yml
+++ b/config/messages.sample.yml
@@ -14,6 +14,7 @@ dialog:
   <<: *common
 intarctive:
   text_notification: "以下の内容で受け付けました。受け付け完了までしばらくお待ちください :pray:"
+  dm_text_notification: "以下の内容で受け付けました。受け付け完了までしばらくお待ちください :pray: \n受付が完了すると入館IDとバーコードがslackbotで届きます:mailbox_with_mail:"
   <<: *common
 notification:
   text_notification: "入館受付が完了しました :tada:"

--- a/config/messages.yml
+++ b/config/messages.yml
@@ -14,6 +14,7 @@ dialog:
   <<: *common
 intarctive:
   text_notification: "以下の内容で受け付けました。受け付け完了までしばらくお待ちください :pray:"
+  dm_text_notification: "以下の内容で受け付けました。受け付け完了までしばらくお待ちください :pray: \n受付が完了すると入館IDとバーコードがslackbotで届きます:mailbox_with_mail:"
   <<: *common
 notification:
   text_notification: "入館受付が完了しました :tada:"

--- a/sample.env
+++ b/sample.env
@@ -1,6 +1,6 @@
 # Slack App OAuth Access Token
 SLACK_TOKEN='xoxp-'
-# Slack への通知チャンネル (only public)
+# Slack への通知チャンネル
 SLACK_CHANNEL='#reception'
 # srd-gate.com の認証ユーザー
 SRD_GATE_USERNAME=""
@@ -12,3 +12,5 @@ MAIL_ADDRESS_HOST=""
 MAIL_ADDRESS_WEBHOOK=""
 # 会社の電話番号（申請に必要）
 COMPANY_TEL="03-1234-5678"
+# 通知の送信先（Public or Private or Both）
+SEND_MODE=""

--- a/sample.env
+++ b/sample.env
@@ -12,5 +12,5 @@ MAIL_ADDRESS_HOST=""
 MAIL_ADDRESS_WEBHOOK=""
 # 会社の電話番号（申請に必要）
 COMPANY_TEL="03-1234-5678"
-# 通知の送信先（Public or Private or Both）
+# 通知の送信先（CHANNEL or DM or BOTH）
 SEND_MODE=""

--- a/spec/app/models/admission_code_message_spec.rb
+++ b/spec/app/models/admission_code_message_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require_relative "../../../app/models/email"
 require_relative "../../../app/models/admission_code_message"
+require_relative "../../../app/models/chat_message_sender"
 
 describe AdmissionCodeMessage do
   let(:instance) { described_class.new(email) }
@@ -28,6 +29,52 @@ describe AdmissionCodeMessage do
       　　<img src='12345678901.BMP' width='200'><BR>
       <BR>
     EMAIL_BODY
+  end
+
+  describe "#post" do
+    # SEND_MODE が CHANNEL の場合
+    # post_public_message が1回呼ばれること
+    context "SEND_MODE が CHANNEL の場合" do
+      it "post_public_message が1回呼ばれること" do
+        allow(ENV).to receive(:fetch).with("SEND_MODE").and_return("CHANNEL")
+        allow(ENV).to receive(:fetch).with("SLACK_CHANNEL").and_return("CH15TJXEX")
+        chat_message_sender = instance_double(ChatMessageSender)
+        allow(ChatMessageSender).to receive(:new).and_return(chat_message_sender)
+        allow(chat_message_sender).to receive(:post_public_message)
+
+        instance.post
+
+        expect(chat_message_sender).to have_received(:post_public_message).once
+      end
+    end
+
+    context "SEND_MODE が DM の場合" do
+      it "post_direct_message が1回呼ばれること" do
+        allow(ENV).to receive(:fetch).with("SEND_MODE").and_return("DM")
+        allow(ENV).to receive(:fetch).with("SLACK_CHANNEL").and_return("CH15TJXEX")
+        chat_message_sender = instance_double(ChatMessageSender)
+        allow(ChatMessageSender).to receive(:new).and_return(chat_message_sender)
+        allow(chat_message_sender).to receive(:post_public_message)
+
+        instance.post
+
+        expect(chat_message_sender).to have_received(:post_public_message).once
+      end
+    end
+
+    context "SEND_MODE が BOTH の場合" do
+      it "post_public_message が2回呼ばれること" do
+        allow(ENV).to receive(:fetch).with("SEND_MODE").and_return("BOTH")
+        allow(ENV).to receive(:fetch).with("SLACK_CHANNEL").and_return("CH15TJXEX")
+        chat_message_sender = instance_double(ChatMessageSender)
+        allow(ChatMessageSender).to receive(:new).and_return(chat_message_sender)
+        allow(chat_message_sender).to receive(:post_public_message)
+
+        instance.post
+
+        expect(chat_message_sender).to have_received(:post_public_message).twice
+      end
+    end
   end
 
   describe "#api_post_body" do

--- a/spec/app/models/admission_code_message_spec.rb
+++ b/spec/app/models/admission_code_message_spec.rb
@@ -32,8 +32,6 @@ describe AdmissionCodeMessage do
   end
 
   describe "#post" do
-    # SEND_MODE が CHANNEL の場合
-    # post_public_message が1回呼ばれること
     context "SEND_MODE が CHANNEL の場合" do
       it "post_public_message が1回呼ばれること" do
         allow(ENV).to receive(:fetch).with("SEND_MODE").and_return("CHANNEL")


### PR DESCRIPTION
## やりたいこと

入館に必要なQRコードの送信先を選べるようにする

## やったこと

- メッセージの送信先を設定ファイルの内容によって変更できるようにしました。
- CHANNELの場合
  - チャンネルのみにメッセージを通知する
  - 投稿されたメッセージのスレッドに詳細情報を通知する
- DMの場合
  - ワークフローの申請者のDMのみにメッセージを通知する
  - DMに投稿されたメッセージのスレッドに詳細情報を通知する
- BOTH の場合
  - チャンネルとDMどちらともにメッセージを投稿する
  - DMに投稿されたメッセージのみに詳細情報を通知する