### PR TITLE
rackのversionを2系に固定します

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ ruby File.read(".ruby-version").rstrip
 gem "activesupport"
 gem "config"
 gem "mechanize"
+gem "rack", "~> 2.2"
 gem "roda"
 gem "sidekiq"
 gem "slack-ruby-client"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby File.read(".ruby-version").rstrip
 gem "activesupport"
 gem "config"
 gem "mechanize"
-gem "rack", "~> 2.2"
+gem "rack", "< 3"
 gem "roda"
 gem "sidekiq"
 gem "slack-ruby-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       method_source (~> 1.0)
     public_suffix (5.0.4)
     racc (1.7.3)
-    rack (3.0.11)
+    rack (2.2.9)
     rainbow (3.1.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -179,6 +179,7 @@ DEPENDENCIES
   guard
   guard-rspec
   mechanize
+  rack (~> 2.2)
   roda
   rspec (~> 3.12)
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ DEPENDENCIES
   guard
   guard-rspec
   mechanize
-  rack (~> 2.2)
+  rack (< 3)
   roda
   rspec (~> 3.12)
   rubocop


### PR DESCRIPTION
## やりたいこと

Rack 3.0.0のバージョンから、rackupのgemが切り離された影響で rackupのコマンドが利用できない状態。
rackupを明示的に入れても良いが、rackupを使い続けるかも含めて検討したいので、一旦2系に固定したい。

## やったこと

- gemfileにてrackのversionを2系に固定しました
