### PR TITLE
🔧 Update bundler 2.5.6 depending on heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,4 +192,4 @@ RUBY VERSION
    ruby 3.3.2p78
 
 BUNDLED WITH
-   2.4.21
+   2.5.6


### PR DESCRIPTION
ローカル環境とheroku環境のbundlerにバージョン差が生じているかと思いますので、それを解消します。
（環境差はなければないほど良いため）

ref: https://devcenter.heroku.com/articles/bundler-version#bundler-2-4-22-and-2-5-6

レビューをお願いします 🙏 