### PR TITLE
sidekiqの設定をworkerで読み込んでいないのを修正

### DIFF
--- a/app/workers/reception_worker.rb
+++ b/app/workers/reception_worker.rb
@@ -5,6 +5,7 @@ require "sidekiq"
 require "slack-ruby-client"
 require_relative "../models/slack_modal_submission"
 require_relative "../models/slack_message"
+require_relative "../../config/initializers/sidekiq.rb"
 
 class ReceptionWorker
   include Sidekiq::Worker

--- a/app/workers/reception_worker.rb
+++ b/app/workers/reception_worker.rb
@@ -5,7 +5,7 @@ require "sidekiq"
 require "slack-ruby-client"
 require_relative "../models/slack_modal_submission"
 require_relative "../models/slack_message"
-require_relative "../../config/initializers/sidekiq.rb"
+require_relative "../../config/initializers/sidekiq"
 
 class ReceptionWorker
   include Sidekiq::Worker


### PR DESCRIPTION
initializers内に定義されている `sidekiq.rb` が require_relative されておらず、SSL等の設定が反映されていない。
そのため、heroku等の環境で該当の設定が必要とされた場合にエラーになってしまうのを修正します。